### PR TITLE
Bump the version of xml-crypto we're using

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "main": "./lib/saml.js",
   "dependencies": {
     "q": "1.0.x",
-    "xml-crypto": "^0.6.0",
+    "xml-crypto": "Asana/xml-crypto#e0fe51110508a1d04ebcbb5a7ba849a198661271",
     "xml-encryption": "~0.7",
     "xml2js": "0.4.x",
     "xmlbuilder": "~2.2",


### PR DESCRIPTION
- this updates to (the equivalent of) xml-crypto@0.10.1 upstream,
  plus various bug-fixes (since that library seems dormant)
- pinned dependency version to a commit hash (https://github.com/Asana/xml-crypto/commit/e0fe51110508a1d04ebcbb5a7ba849a198661271)
- all tests pass