### PR TITLE
Update xml-crypto dependency to include fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "main": "./lib/saml.js",
   "dependencies": {
     "q": "1.0.x",
-    "xml-crypto": "Asana/xml-crypto#bcccb8067a73ddb78f0fe9edec2196fb9292b54c",
+    "xml-crypto": "Asana/xml-crypto#fe47b7ffac6c0f460d3802ba578c8a340218a28f",
     "xml-encryption": "~0.7",
     "xml2js": "0.4.x",
     "xmlbuilder": "~2.2",


### PR DESCRIPTION
Update the `xml-crypto` dependency so that it uses a version of `xml-crypto` that contains the fix for the [AT&T SAML issue](https://app.asana.com/0/815188709102173/1191087470041955).

[Link to commit `fe47b7ffac6c0f460d3802ba578c8a340218a28f`](https://github.com/Asana/xml-crypto/commit/fe47b7ffac6c0f460d3802ba578c8a340218a28f).

https://app.asana.com/0/815188709102173/1192410228611211