### PR TITLE
Change xml2js version to 0.4.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "q": "1.0.x",
     "xml-crypto": "Asana/xml-crypto#fe47b7ffac6c0f460d3802ba578c8a340218a28f",
     "xml-encryption": "~0.7",
-    "xml2js": "0.4.x",
+    "xml2js": "0.4.19",
     "xmlbuilder": "~2.2",
     "xmldom": "^0.1.19"
   },


### PR DESCRIPTION
**This fixes the unit tests which are currently failing on `master`.**

**TLDR:** the unit tests pass when the version of `xml2js` is `0.4.19`, but not when it's `0.4.x` (which resolves to `0.4.23`).

---

I noticed that the [test failures on master](https://travis-ci.org/github/Asana/node-saml-lib/builds/724285329) had to do with `xml2js`. 

I then noticed that the version specified in `package.json` was `0.4.x`, which ends up resolving to `0.4.23` when running `npm install` on the `saml-lib` package. In `codez`, however, the `xml2js` version that is actually checked in is [`0.4.19`](https://github.com/Asana/codez/blob/next-master/node0/node_modules/saml-lib/node_modules/xml2js/package.json#L313). 

So, I changed the version here to be locked in to `0.4.19`, and unit tests passed 🥳 

Since [the failure I got when exercising the code](https://asana.slack.com/archives/C01A9Q4384A/p1599603847036900) in sand was the same as the failure seen in these failed unit tests, I am hopeful that this will resolve the issue in sand.

