### PR TITLE
Skip attributes with no value

### DIFF
--- a/lib/saml.js
+++ b/lib/saml.js
@@ -619,6 +619,19 @@ SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callb
       if (attributes) {
         attributes.forEach(function (attribute) {
           var value = attribute.AttributeValue;
+          if (value === undefined) {
+            /** Skip attributes with no value.
+             *
+             * As per SAML spec:
+             *    The meaning of an <Attribute> element that contains no <AttributeValue> elements depends on its context.
+             *    Within an <AttributeStatement>, if the SAML attribute exists but has no values,
+             *    then the <AttributeValue> element MUST be omitted.
+             *
+             * Source: page 30, lines 1218-1220 https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf
+             */
+            return;
+          }
+
           if (value.length === 1) {
             profile[attribute.$.Name] = attrValueMapper(value[0]);
           } else {


### PR DESCRIPTION
Most attributes in SAML response have attribute values, e.g.:
```
<saml:Attribute ...>
    <saml:AttributeValue
        ...>
            ....
    </saml:AttributeValue>
</saml:Attribute>
```

However, some attributes might not have any value, e.g.:
```
<saml:Attribute .../>
```

This is a valid behavior, as per SAML docs:
> The meaning of an <Attribute> element that contains no <AttributeValue> elements depends on its context.
> Within an <AttributeStatement>, if the SAML attribute exists but has no values, then the <AttributeValue> element MUST be omitted.

_Source: page 30, lines 1218-1220 https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf_

But our current code crashes if it sees an Attribute without a value.

In this fix we skip attributes with no value

<hr>

I tested this change manually using a response with an empty attribute, and confirmed that it crashes _without_ the fix, and works _with_ this fix.